### PR TITLE
도메인 수정 - 회원 계정과 게시글, 댓글 관계 연결

### DIFF
--- a/src/main/java/com/fastcampus/boardpractice/controller/MainController.java
+++ b/src/main/java/com/fastcampus/boardpractice/controller/MainController.java
@@ -1,0 +1,12 @@
+package com.fastcampus.boardpractice.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class MainController {
+    @GetMapping("/")
+    public String root() {
+        return "redirect:/articles";
+    }
+}

--- a/src/main/java/com/fastcampus/boardpractice/dto/ArticleCommentDto.java
+++ b/src/main/java/com/fastcampus/boardpractice/dto/ArticleCommentDto.java
@@ -1,0 +1,20 @@
+package com.fastcampus.boardpractice.dto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * DTO for {@link com.fastcampus.boardpractice.domain.ArticleComment}
+ */
+public record ArticleCommentDto(
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy,
+        String content
+) {
+    public static ArticleCommentDto of(LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, String content){
+        return new ArticleCommentDto(createdAt, createdBy, modifiedAt, modifiedBy, content);
+    }
+
+}

--- a/src/main/java/com/fastcampus/boardpractice/dto/ArticleDto.java
+++ b/src/main/java/com/fastcampus/boardpractice/dto/ArticleDto.java
@@ -1,0 +1,17 @@
+package com.fastcampus.boardpractice.dto;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+public record ArticleDto(
+        LocalDateTime createdAt,
+        String createdBy,
+        String title,
+        String content,
+        String hashtag
+) {
+    public static ArticleDto of(LocalDateTime createdAt, String createdBy, String title, String content, String hashtag) {
+        return new ArticleDto(createdAt, createdBy, title, content, hashtag);
+    }
+    
+}

--- a/src/main/java/com/fastcampus/boardpractice/dto/ArticleUpdateDto.java
+++ b/src/main/java/com/fastcampus/boardpractice/dto/ArticleUpdateDto.java
@@ -1,0 +1,15 @@
+package com.fastcampus.boardpractice.dto;
+
+/**
+ * DTO for {@link com.fastcampus.boardpractice.domain.Article}
+ */
+public record ArticleUpdateDto(
+        String title,
+        String content,
+        String hashtag
+) {
+    public static ArticleUpdateDto of(String title, String content, String hashtag) {
+        return new ArticleUpdateDto(title, content, hashtag);
+    }
+
+}

--- a/src/main/java/com/fastcampus/boardpractice/service/ArticleCommentService.java
+++ b/src/main/java/com/fastcampus/boardpractice/service/ArticleCommentService.java
@@ -1,0 +1,33 @@
+package com.fastcampus.boardpractice.service;
+
+import com.fastcampus.boardpractice.domain.ArticleComment;
+import com.fastcampus.boardpractice.dto.ArticleCommentDto;
+import com.fastcampus.boardpractice.dto.ArticleDto;
+import com.fastcampus.boardpractice.dto.ArticleUpdateDto;
+import com.fastcampus.boardpractice.repository.ArticleCommentRepository;
+import com.fastcampus.boardpractice.repository.ArticleRepository;
+import com.fastcampus.boardpractice.type.SearchType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor //필수 필드에 대한 생성자를 자동으로 생성해줌
+@Transactional
+@Service
+public class ArticleCommentService {
+
+    private final ArticleRepository articleRepository;
+    private final ArticleCommentRepository articleCommentRepository;
+
+    @Transactional(readOnly = true)
+    public List<ArticleCommentDto> searchArticleComment(Long articleId) {
+        return List.of();
+    }
+
+    public void saveArticleComment(ArticleCommentDto dto) {
+    }
+
+}

--- a/src/main/java/com/fastcampus/boardpractice/service/ArticleService.java
+++ b/src/main/java/com/fastcampus/boardpractice/service/ArticleService.java
@@ -1,0 +1,38 @@
+package com.fastcampus.boardpractice.service;
+
+import com.fastcampus.boardpractice.dto.ArticleDto;
+import com.fastcampus.boardpractice.dto.ArticleUpdateDto;
+import com.fastcampus.boardpractice.repository.ArticleRepository;
+import com.fastcampus.boardpractice.type.SearchType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@RequiredArgsConstructor //필수 필드에 대한 생성자를 자동으로 생성해줌
+@Transactional
+@Service
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+
+    @Transactional(readOnly = true)
+    public Page<ArticleDto> searchArticles(SearchType title, String search_keyword) {
+        return Page.empty();
+    }
+
+    @Transactional(readOnly = true)
+    public ArticleDto searchArticle(long l) {
+        return null;
+    }
+
+    public void saveArticle(ArticleDto dto) {
+    }
+
+    public void updateArticle(long articleId, ArticleUpdateDto dto) {
+    }
+
+    public void deleteArticle(long articleId) {
+    }
+}

--- a/src/main/java/com/fastcampus/boardpractice/type/SearchType.java
+++ b/src/main/java/com/fastcampus/boardpractice/type/SearchType.java
@@ -1,0 +1,5 @@
+package com.fastcampus.boardpractice.type;
+
+public enum SearchType {
+    TITLE, CONTENT, ID, NICKNAME, HASHTAG
+}

--- a/src/test/java/com/fastcampus/boardpractice/controller/AuthControllerTest.java
+++ b/src/test/java/com/fastcampus/boardpractice/controller/AuthControllerTest.java
@@ -30,7 +30,7 @@ public class AuthControllerTest {
 
         // When & Then
         mvc.perform(get("/login"))
-                .andExpect(status().isOk())
+                .andExpect(status().isOk()) //200이면 ok
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML));
     }
 

--- a/src/test/java/com/fastcampus/boardpractice/controller/MainControllerTest.java
+++ b/src/test/java/com/fastcampus/boardpractice/controller/MainControllerTest.java
@@ -1,0 +1,39 @@
+package com.fastcampus.boardpractice.controller;
+
+import com.fastcampus.boardpractice.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("main 컨트롤러 - home버튼")
+@Import(SecurityConfig.class) //Security설정이 모두 통과하도록 설정
+@WebMvcTest(ArticleController.class)
+class MainControllerTest {
+
+    private final MockMvc mvc;
+
+    public MainControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[view][GET] 로그인 페이지 - 정상 호출")
+    @Test
+    public void givenNothing_whenRequestingRootPage_thenReturnsArticlesPage() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/"))
+                .andExpect(view().name("forward:/articles"))
+                .andExpect(forwardedUrl("/articles"))
+                .andDo(MockMvcResultHandlers.print());
+    }
+
+}

--- a/src/test/java/com/fastcampus/boardpractice/service/ArticleCommentServiceTest.java
+++ b/src/test/java/com/fastcampus/boardpractice/service/ArticleCommentServiceTest.java
@@ -1,0 +1,65 @@
+package com.fastcampus.boardpractice.service;
+
+import com.fastcampus.boardpractice.domain.Article;
+import com.fastcampus.boardpractice.domain.ArticleComment;
+import com.fastcampus.boardpractice.dto.ArticleCommentDto;
+import com.fastcampus.boardpractice.dto.ArticleDto;
+import com.fastcampus.boardpractice.repository.ArticleCommentRepository;
+import com.fastcampus.boardpractice.repository.ArticleRepository;
+import com.fastcampus.boardpractice.type.SearchType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("비즈니스 로직 - 댓글")
+@ExtendWith(MockitoExtension.class)
+class ArticleCommentServiceTest {
+
+    @InjectMocks private ArticleCommentService sut;
+
+    @Mock private ArticleRepository articleRepository;
+    @Mock private ArticleCommentRepository articleCommentRepository;
+
+    @DisplayName("게시글 ID로 조회하면, 해당하는 댓글 리스트를 반환한다.")
+    @Test
+    void givenArticleId_whenSearchingArticleComments_thenReturnsArticleComments() {
+        // Given
+        Long articleId = 1L;
+        given(articleRepository.findById(articleId)).willReturn(Optional.of(
+                Article.of("title", "content", "#java"))
+        );
+
+        // When
+        List<ArticleCommentDto> articleComments = sut.searchArticleComment(articleId);
+
+        //Then
+        assertThat(articleComments).isNotNull();
+        then(articleRepository).should().findById(articleId);
+    }
+
+    @DisplayName("댓글 정보를 입력하면, 댓글을 저장한다.")
+    @Test
+    void givenArticleCommentInfo_whenSavingArticleComment_thenSavesArticleComment() {
+        // Given
+        given(articleCommentRepository.save(any(ArticleComment.class))).willReturn(null);
+
+        // When
+        sut.saveArticleComment(ArticleCommentDto.of(LocalDateTime.now(), "Uno", LocalDateTime.now(), "Uno", "content"));
+
+        // Then
+        then(articleCommentRepository).should().save(any(ArticleComment.class));
+    }
+
+}

--- a/src/test/java/com/fastcampus/boardpractice/service/ArticleServiceTest.java
+++ b/src/test/java/com/fastcampus/boardpractice/service/ArticleServiceTest.java
@@ -1,0 +1,96 @@
+package com.fastcampus.boardpractice.service;
+
+import com.fastcampus.boardpractice.domain.Article;
+import com.fastcampus.boardpractice.dto.ArticleDto;
+import com.fastcampus.boardpractice.dto.ArticleUpdateDto;
+import com.fastcampus.boardpractice.repository.ArticleRepository;
+import com.fastcampus.boardpractice.type.SearchType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
+
+//스프링부트 애플리케이션 띄우는 기능 생략하기 위해 슬라이스 테스트 기능을 사용하지 않음
+// 가벼운 테스트를 만들기 위함. 대신 dependency가 추가되어야 하면 모킹 방식 사용.(mockioto)
+@DisplayName("비즈니스 로직 - 게시글")
+@ExtendWith({MockitoExtension.class})
+class ArticleServiceTest {
+
+    @InjectMocks private ArticleService sut; //sut : system under test로 테스트 대상임을 뜻함.
+    @Mock private ArticleRepository articleRepository; //의존하는 대상
+
+    @DisplayName("게시글을 검색하면, 게시글 리스트를 반환한다")
+    @Test
+    void givenSearchParameters_whenSearchingArticles_thenReturnsArticleList(){
+        // Given
+
+        // When
+        //검색 대상 : 제목, 본문, ID, 닉네임, 해시태그
+        Page<ArticleDto> articles = sut.searchArticles(SearchType.TITLE, "search keyword");
+
+        //Then
+        assertThat(articles).isNotNull();
+    }
+
+    @DisplayName("게시글을 조회하면, 게시글을 반환한다.")
+    @Test
+    void givenArticleId_whenSearchingArticle_thenReturnsArticle() {
+        // Given
+
+        // When
+        ArticleDto articles = sut.searchArticle(1L);
+
+        // Then
+        assertThat(articles).isNotNull();
+    }
+
+    @DisplayName("게시글 정보를 입력하면, 게시글을 생성한다")
+    @Test
+    void givenArticleInfo_whenSavingArticle_thenSavesArticle(){
+        // Given
+        given(articleRepository.save(any(Article.class))).willReturn(null);
+
+        // When
+        sut.saveArticle(ArticleDto.of(LocalDateTime.now(), "Uno", "title", "content", "#java"));
+
+        // Then
+        then(articleRepository).should().save(any(Article.class));
+    }
+
+    @DisplayName("게시글의 ID와 수정 정보를 입력하면, 게시글을 수정한다")
+    @Test
+    void givenArticleIdAndModifiedInfo_whenUpdatingArticle_thenUpdatesArticle() {
+        // Given
+        given(articleRepository.save(any(Article.class))).willReturn(null);
+
+        // When
+        sut.updateArticle(1L, ArticleUpdateDto.of("title", "content", "#java"));
+
+        // Then
+        then(articleRepository).should().save(any(Article.class));
+    }
+
+    @DisplayName("게시글의 ID를 입력하면, 게시글을 삭제한다")
+    @Test
+    void givenArticleId_whenDeletingArticle_thenDeletesArticle() {
+        // Given
+        willDoNothing().given(articleRepository).delete(any(Article.class));
+
+        // When
+        sut.deleteArticle(1L);
+
+        // Then
+        then(articleRepository).should().delete(any(Article.class));
+    }
+
+}


### PR DESCRIPTION
#20 전 단계로 회원 계정을 추가함.

게시글과 댓글은 모두 회원이 작성하기 때문에, 그 연관관계를 ERD와 java 코드 수정함.

createdBy를 작성자로 생각하고 다룰 수도 있지만, 해당 필드는 작성자와 직접적인 연관이 맺어져있지 않기 때문에
이 문제를 확인하고 수정함.