### PR TITLE
#45 - 도메인 업데이트: UserAccount 회원 ID에 유니크 키 추가

### DIFF
--- a/src/main/java/com/fastcampus/boardpractice/service/ArticleCommentService.java
+++ b/src/main/java/com/fastcampus/boardpractice/service/ArticleCommentService.java
@@ -1,34 +1,52 @@
 package com.fastcampus.boardpractice.service;
 
+import com.fastcampus.boardpractice.domain.ArticleComment;
 import com.fastcampus.boardpractice.dto.ArticleCommentDto;
 import com.fastcampus.boardpractice.repository.ArticleCommentRepository;
 import com.fastcampus.boardpractice.repository.ArticleRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-@RequiredArgsConstructor //필수 필드에 대한 생성자를 자동으로 생성해줌
+@Slf4j
+@RequiredArgsConstructor
 @Transactional
 @Service
 public class ArticleCommentService {
-
     private final ArticleRepository articleRepository;
     private final ArticleCommentRepository articleCommentRepository;
 
     @Transactional(readOnly = true)
     public List<ArticleCommentDto> searchArticleComments(Long articleId) {
-        return List.of();
+        return articleCommentRepository.findByArticle_Id(articleId)
+                .stream()
+                .map(ArticleCommentDto::from)
+                .toList();
     }
 
     public void saveArticleComment(ArticleCommentDto dto) {
+        try {
+            articleCommentRepository.save(dto.toEntity(articleRepository.getReferenceById(dto.articleId())));
+        } catch (EntityNotFoundException e) {
+            log.warn("댓글 저장 실패. 댓글의 게시글을 찾을 수 없습니다 - dto: {}", dto);
+        }
     }
 
     public void updateArticleComment(ArticleCommentDto dto) {
+        try {
+            ArticleComment articleComment = articleCommentRepository.getReferenceById(dto.id());
+            if (dto.content() != null) { articleComment.setContent(dto.content()); }
+        } catch (EntityNotFoundException e) {
+            log.warn("댓글 업데이트 실패. 댓글을 찾을 수 없습니다 - dto: {}", dto);
+        }
     }
 
     public void deleteArticleComment(Long articleCommentId) {
+        articleCommentRepository.deleteById(articleCommentId);
     }
 
 }

--- a/src/test/java/com/fastcampus/boardpractice/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/boardpractice/repository/JpaRepositoryTest.java
@@ -54,7 +54,7 @@ class JpaRepositoryTest {
     void givenTestData_whenInserting_thenWorksFine() {
         // Given
         long previousCount = articleRepository.count();
-        UserAccount userAccount = userAccountRepository.save(UserAccount.of("uno", "pw", null, null, null));
+        UserAccount userAccount = userAccountRepository.save(UserAccount.of("newUno", "pw", null, null, null));
         Article article = Article.of(userAccount, "new article", "new content", "#spring");
 
         // When


### PR DESCRIPTION
회원 id로 로그인하고 유저 식별하므로, 당연히 uk 여야 한다.
이 부분이 설계에서 반영되지 않았던 것을 발견 테스트는 uk 적용으로 기존 `data.sql`의 테스트 데이터와 중복이 발생하므로 `userId` 이름을 수정